### PR TITLE
Solucion relacion xbalance con tipoasiento

### DIFF
--- a/src/main/java/net/ausiasmarch/contante/api/Tipoasiento.java
+++ b/src/main/java/net/ausiasmarch/contante/api/Tipoasiento.java
@@ -47,7 +47,13 @@ public class Tipoasiento {
         return new ResponseEntity<Long>(oTipoAsientoService.count(), HttpStatus.OK);
     }
 
-     @DeleteMapping("/{id}")
+    @GetMapping("/xbalance/{id}")
+    public ResponseEntity<Page<TipoasientoEntity>> getByBalance(Pageable oPageable, @PathVariable Long id) {
+        return new ResponseEntity<Page<TipoasientoEntity>>(oTipoAsientoService.getPageByBalance(oPageable, id),
+                HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
     public ResponseEntity<Long> delete(@PathVariable Long id) {
         return new ResponseEntity<Long>(oTipoAsientoService.delete(id), HttpStatus.OK);
     }
@@ -70,5 +76,17 @@ public class Tipoasiento {
     @DeleteMapping("/all")
     public ResponseEntity<Long> deleteAll() {
         return new ResponseEntity<Long>(oTipoAsientoService.deleteAll(), HttpStatus.OK);
+    }
+
+    // quitar relacion con parametros de tipoasiento y balance
+    @DeleteMapping("/quitarBalance")
+    public ResponseEntity<Long> deleteRelation(@RequestParam Long idTipoasiento, @RequestParam Long idBalance) {
+        return new ResponseEntity<Long>(oTipoAsientoService.deleteRelation(idTipoasiento, idBalance), HttpStatus.OK);
+    }
+
+    // agregar relacion con parametros de tipoasiento y balance
+    @PutMapping("/agregarBalance")
+    public ResponseEntity<Long> addRelation(@RequestParam Long idTipoasiento, @RequestParam Long idBalance) {
+        return new ResponseEntity<Long>(oTipoAsientoService.addRelation(idTipoasiento, idBalance), HttpStatus.OK);
     }
 }

--- a/src/main/java/net/ausiasmarch/contante/api/Tipoasiento.java
+++ b/src/main/java/net/ausiasmarch/contante/api/Tipoasiento.java
@@ -48,8 +48,17 @@ public class Tipoasiento {
     }
 
     @GetMapping("/xbalance/{id}")
-    public ResponseEntity<Page<TipoasientoEntity>> getByBalance(Pageable oPageable, @PathVariable Long id) {
-        return new ResponseEntity<Page<TipoasientoEntity>>(oTipoAsientoService.getPageByBalance(oPageable, id),
+    public ResponseEntity<Page<TipoasientoEntity>> getByBalance(Pageable oPageable, @PathVariable Long id,
+            @RequestParam Optional<String> filter) {
+        return new ResponseEntity<Page<TipoasientoEntity>>(oTipoAsientoService.getPageByBalance(oPageable, id, filter),
+                HttpStatus.OK);
+    }
+
+    @GetMapping("/wherebalanceisnot/{id}")
+    public ResponseEntity<Page<TipoasientoEntity>> getTipoasientoSinRelacionar(Pageable oPageable,
+            @PathVariable Long id, @RequestParam Optional<String> filter) {
+        return new ResponseEntity<Page<TipoasientoEntity>>(
+                oTipoAsientoService.getTipoasientoSinRelacionar(id, oPageable, filter),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/net/ausiasmarch/contante/repository/TipoasientoRepository.java
+++ b/src/main/java/net/ausiasmarch/contante/repository/TipoasientoRepository.java
@@ -3,12 +3,36 @@ package net.ausiasmarch.contante.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import jakarta.transaction.Transactional;
 import net.ausiasmarch.contante.entity.TipoasientoEntity;
 
-public interface TipoasientoRepository extends JpaRepository <TipoasientoEntity, Long> {
-    
+public interface TipoasientoRepository extends JpaRepository<TipoasientoEntity, Long> {
+
     Page<TipoasientoEntity> findByDescripcionContaining(
             String filter, Pageable oPageable);
 
+    @Query(value = """
+            SELECT ta.* FROM tipoasiento ta
+            JOIN grupotipoasiento gta ON ta.id = gta.id_tipoasiento
+            JOIN balance b ON gta.id_balance = b.id
+            WHERE b.id = :idBalance
+            """, nativeQuery = true)
+    Page<TipoasientoEntity> findByBalance(Pageable oPageable, Long idBalance);
+
+    @Transactional
+    @Modifying
+    @Query(value = """
+            DELETE FROM grupotipoasiento WHERE id_tipoasiento = :idTipoasiento AND id_balance = :idBalance
+            """, nativeQuery = true)
+    int deleteRelation(Long idTipoasiento, Long idBalance);
+
+    @Transactional
+    @Modifying
+    @Query(value = """
+            INSERT INTO grupotipoasiento (id_tipoasiento, id_balance, titulo, descripcion, orden) VALUES (:idTipoasiento, :idBalance, '', '', 0)
+            """, nativeQuery = true)
+    int addRelation(Long idTipoasiento, Long idBalance);
 }

--- a/src/main/java/net/ausiasmarch/contante/repository/TipoasientoRepository.java
+++ b/src/main/java/net/ausiasmarch/contante/repository/TipoasientoRepository.java
@@ -1,38 +1,57 @@
 package net.ausiasmarch.contante.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import jakarta.transaction.Transactional;
 import net.ausiasmarch.contante.entity.TipoasientoEntity;
 
 public interface TipoasientoRepository extends JpaRepository<TipoasientoEntity, Long> {
 
-    Page<TipoasientoEntity> findByDescripcionContaining(
-            String filter, Pageable oPageable);
+        Page<TipoasientoEntity> findByDescripcionContaining(
+                        String filter, Pageable oPageable);
 
-    @Query(value = """
-            SELECT ta.* FROM tipoasiento ta
-            JOIN grupotipoasiento gta ON ta.id = gta.id_tipoasiento
-            JOIN balance b ON gta.id_balance = b.id
-            WHERE b.id = :idBalance
-            """, nativeQuery = true)
-    Page<TipoasientoEntity> findByBalance(Pageable oPageable, Long idBalance);
+        @Query(value = """
+                        SELECT ta.id, ta.descripcion
+                        FROM tipoasiento ta
+                        JOIN grupotipoasiento gta ON ta.id = gta.id_tipoasiento
+                        JOIN balance b ON gta.id_balance = b.id
+                        WHERE b.id = :idBalance
+                        AND (:filter IS NULL OR ta.descripcion LIKE %:filter%)
+                                            """, nativeQuery = true)
+        Page<TipoasientoEntity> findByBalance(Pageable oPageable, Long idBalance, Optional<String> filter);
 
-    @Transactional
-    @Modifying
-    @Query(value = """
-            DELETE FROM grupotipoasiento WHERE id_tipoasiento = :idTipoasiento AND id_balance = :idBalance
-            """, nativeQuery = true)
-    int deleteRelation(Long idTipoasiento, Long idBalance);
+        @Transactional
+        @Modifying
+        @Query(value = """
+                        DELETE FROM grupotipoasiento WHERE id_tipoasiento = :idTipoasiento AND id_balance = :idBalance
+                        """, nativeQuery = true)
+        int deleteRelation(Long idTipoasiento, Long idBalance);
 
-    @Transactional
-    @Modifying
-    @Query(value = """
-            INSERT INTO grupotipoasiento (id_tipoasiento, id_balance, titulo, descripcion, orden) VALUES (:idTipoasiento, :idBalance, '', '', 0)
-            """, nativeQuery = true)
-    int addRelation(Long idTipoasiento, Long idBalance);
+        @Transactional
+        @Modifying
+        @Query(value = """
+                        INSERT INTO grupotipoasiento (id_tipoasiento, id_balance, titulo, descripcion, orden) VALUES (:idTipoasiento, :idBalance, '', '', 0)
+                        """, nativeQuery = true)
+        int addRelation(Long idTipoasiento, Long idBalance);
+
+        @Query(value = """
+                        SELECT ta.id, ta.descripcion
+                        FROM tipoasiento ta
+                        WHERE ta.id NOT IN (
+                            SELECT gta.id_tipoasiento
+                            FROM grupotipoasiento gta
+                            WHERE gta.id_balance = :idBalance
+                        )
+                        AND (:filter IS NULL OR ta.descripcion LIKE %:filter%)
+                        """, nativeQuery = true)
+        Page<TipoasientoEntity> getTipoasientoSinRelacionar(Long idBalance, Pageable oPageable,
+                        @Param("filter") Optional<String> filter);
+
 }

--- a/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
+++ b/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
@@ -27,12 +27,13 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
     };
 
     public Long randomCreate(Long cantidad) {
-        // for each element in the array arrDescripciones, create a new TipoasientoEntity object and save it to the database
+        // for each element in the array arrDescripciones, create a new
+        // TipoasientoEntity object and save it to the database
         for (String descripcion : arrDescripciones) {
             TipoasientoEntity oTipoAsientoEntity = new TipoasientoEntity();
             oTipoAsientoEntity.setDescripcion(descripcion);
             oTipoAsientoRepository.save(oTipoAsientoEntity);
-        }    
+        }
         return oTipoAsientoRepository.count();
     }
 
@@ -45,6 +46,10 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
         } else {
             return oTipoAsientoRepository.findAll(oPageable);
         }
+    }
+
+    public Page<TipoasientoEntity> getPageByBalance(Pageable oPageable, Long id) {
+        return oTipoAsientoRepository.findByBalance(oPageable, id);
     }
 
     public TipoasientoEntity get(Long id) {
@@ -83,5 +88,15 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
     public TipoasientoEntity randomSelection() {
         return oTipoAsientoRepository.findAll()
                 .get(oRandomService.getRandomInt(0, (int) (oTipoAsientoRepository.count() - 1)));
+    }
+
+    public Long deleteRelation(Long idTipoasiento, Long idBalance) {
+        int rowsDeleted = oTipoAsientoRepository.deleteRelation(idTipoasiento, idBalance);
+        return (long) rowsDeleted;
+    }
+
+    public Long addRelation(Long idTipoasiento, Long idBalance) {
+        int rowsAdded = oTipoAsientoRepository.addRelation(idTipoasiento, idBalance);
+        return (long) rowsAdded;
     }
 }

--- a/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
+++ b/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
@@ -48,8 +48,12 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
         }
     }
 
-    public Page<TipoasientoEntity> getPageByBalance(Pageable oPageable, Long id) {
-        return oTipoAsientoRepository.findByBalance(oPageable, id);
+    public Page<TipoasientoEntity> getPageByBalance(Pageable oPageable, Long id, Optional<String> filter) {
+        return oTipoAsientoRepository.findByBalance(oPageable, id, filter);
+    }
+
+    public Page<TipoasientoEntity> getTipoasientoSinRelacionar(Long id, Pageable oPageable, Optional<String> filter) {
+        return oTipoAsientoRepository.getTipoasientoSinRelacionar(id, oPageable, filter);
     }
 
     public TipoasientoEntity get(Long id) {

--- a/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
+++ b/src/main/java/net/ausiasmarch/contante/service/TipoasientoService.java
@@ -36,7 +36,7 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
             oTipoAsientoEntity.setDescripcion(descripcion);
             oTipoAsientoRepository.save(oTipoAsientoEntity);
         }
-        }return oTipoAsientoRepository.count();
+        return oTipoAsientoRepository.count();
 
     }
 
@@ -97,11 +97,6 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
                 .get(oRandomService.getRandomInt(0, (int) (oTipoAsientoRepository.count() - 1)));
     }
 
-    public Long deleteRelation(Long idTipoasiento, Long idBalance) {
-        int rowsDeleted = oTipoAsientoRepository.deleteRelation(idTipoasiento, idBalance);
-        return (long) rowsDeleted;
-    }
-
     public Long addRelation(Long idTipoasiento, Long idBalance) {
         int rowsAdded = oTipoAsientoRepository.addRelation(idTipoasiento, idBalance);
         return (long) rowsAdded;
@@ -110,10 +105,5 @@ public class TipoasientoService implements ServiceInterface<TipoasientoEntity> {
     public Long deleteRelation(Long idTipoasiento, Long idBalance) {
         int rowsDeleted = oTipoAsientoRepository.deleteRelation(idTipoasiento, idBalance);
         return (long) rowsDeleted;
-    }
-
-    public Long addRelation(Long idTipoasiento, Long idBalance) {
-        int rowsAdded = oTipoAsientoRepository.addRelation(idTipoasiento, idBalance);
-        return (long) rowsAdded;
     }
 }


### PR DESCRIPTION
Se ha agregado solución para que el selector solamente envie los tipoasientos que aún no se han relacionado con un balance. Ahora también funcionan los filtros para dichos plist.